### PR TITLE
Fixes #9: widgets do not work after pjax load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 jui extension Change Log
 2.0.5 under development
 -----------------------
 
+- Bug #9: Widgets did not work after a pjax page load (smichae)
 - Bug #8607: `yii\jui\Spinner` was using wrong event names (samdark)
 
 2.0.4 May 10, 2015

--- a/Widget.php
+++ b/Widget.php
@@ -76,7 +76,8 @@ class Widget extends \yii\base\Widget
         if ($this->clientOptions !== false) {
             $options = empty($this->clientOptions) ? '' : Json::htmlEncode($this->clientOptions);
             $js = "jQuery(document).on('ready pjax:success', function() { jQuery('#$id').$name($options); });";
-            $this->getView()->registerJs($js);
+            $view = $this->getView();
+            $view->registerJs($js, $view::POS_END);
         }
     }
 

--- a/Widget.php
+++ b/Widget.php
@@ -75,7 +75,7 @@ class Widget extends \yii\base\Widget
     {
         if ($this->clientOptions !== false) {
             $options = empty($this->clientOptions) ? '' : Json::htmlEncode($this->clientOptions);
-            $js = "jQuery('#$id').$name($options);";
+            $js = "jQuery(document).on('ready pjax:success', function() { jQuery('#$id').$name($options); });";
             $this->getView()->registerJs($js);
         }
     }

--- a/Widget.php
+++ b/Widget.php
@@ -8,6 +8,7 @@
 namespace yii\jui;
 
 use yii\helpers\Json;
+use yii\web\View;
 
 /**
  * \yii\jui\Widget is the base class for all jQuery UI widgets.
@@ -76,8 +77,7 @@ class Widget extends \yii\base\Widget
         if ($this->clientOptions !== false) {
             $options = empty($this->clientOptions) ? '' : Json::htmlEncode($this->clientOptions);
             $js = "jQuery(document).on('ready pjax:success', function() { jQuery('#$id').$name($options); });";
-            $view = $this->getView();
-            $view->registerJs($js, $view::POS_END);
+            $this->getView()->registerJs($js, View::POS_END);
         }
     }
 


### PR DESCRIPTION
Add the pjax:success in addition to ready so the widget is initialized after pjax load as well as initial page load