### PR TITLE
Use `jQuery` instead of `$` in generated code to avoid conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 jui extension Change Log
 -----------------------
 
 - Bug #46: `yii\jui\Selectable` add support for `begin()`, `end()` widget methods (fdezmc)
-- Enh: Use `jQuery` instead of `$` in generated code to avoid conflicts (samdark)
+- Enh #56: Use `jQuery` instead of `$` in generated code to avoid conflicts (samdark)
 
 
 2.0.6 July 22, 2016

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 jui extension Change Log
 -----------------------
 
 - Bug #46: `yii\jui\Selectable` add support for `begin()`, `end()` widget methods (fdezmc)
+- Enh: Use `jQuery` instead of `$` in generated code to avoid conflicts (samdark)
 
 
 2.0.6 July 22, 2016

--- a/DatePicker.php
+++ b/DatePicker.php
@@ -150,7 +150,7 @@ class DatePicker extends InputWidget
             $assetBundle->language = $language;
             $options = Json::htmlEncode($this->clientOptions);
             $language = Html::encode($language);
-            $view->registerJs("$('#{$containerID}').datepicker($.extend({}, $.datepicker.regional['{$language}'], $options));");
+            $view->registerJs("jQuery('#{$containerID}').datepicker($.extend({}, $.datepicker.regional['{$language}'], $options));");
         } else {
             $this->registerClientOptions('datepicker', $containerID);
         }

--- a/SliderInput.php
+++ b/SliderInput.php
@@ -101,7 +101,7 @@ class SliderInput extends InputWidget
 
         if (!isset($this->clientEvents['slide'])) {
             $this->clientEvents['slide'] = 'function (event, ui) {
-                $("#' . $this->options['id'] . '").val(ui.value);
+                jQuery("#' . $this->options['id'] . '").val(ui.value);
             }';
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
