### PR TITLE
Fix value options

### DIFF
--- a/src/DatePicker.php
+++ b/src/DatePicker.php
@@ -168,11 +168,8 @@ class DatePicker extends InputWidget
         $contents = [];
 
         // get formatted date value
-        if ($this->hasModel()) {
-            $value = Html::getAttributeValue($this->model, $this->attribute);
-        } else {
-            $value = $this->value;
-        }
+        $value = $this->value;
+
         if ($value !== null && $value !== '') {
             // format value according to dateFormat
             try {


### PR DESCRIPTION
I suggest to to change the way of get data value from:
```PHP
protected function renderWidget()
{
...
   //get formatted data value
   if($this->hasModel()){
       $value = Html::getAttributeValue($this->model, $this->attribute);
   } else {
       $value = $this->value;
   }
...
}
```
to:
```PHP
protected function renderWidget()
{
...
   //get formatted data value
   $value = $this->value;
...
}
```
Because when condition `$this->hasModel()` is true, value options do not work.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | set 'value' options for use widget with/without  #model
