### PR TITLE
Fix #62 - $.fn.button.noConflict is not a function in JUI dialog

### DIFF
--- a/src/Dialog.php
+++ b/src/Dialog.php
@@ -42,7 +42,7 @@ class Dialog extends Widget
 
         //Fix for closing icon (x) not showing up in dialog
         $this->getView()->registerJs("
-            if ($.fn.button) {
+            if ($.fn.button && $.fn.button.noConflict !== undefined) {
                 var bootstrapButton = $.fn.button.noConflict(); 
                 $.fn.bootstrapBtn = bootstrapButton;
             }",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #62
